### PR TITLE
feat: YAML config support

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -1,5 +1,7 @@
 package client
 
+import "github.com/cloudquery/cq-provider-sdk/cqproto"
+
 // Provider Configuration
 
 type Config struct {
@@ -12,12 +14,22 @@ type Config struct {
 	SpacesAccessKeyId string `hcl:"spaces_access_key_id,optional"`
 	// SpacesDebugLogging allows enabling AWS S3 request logging on spaces requests
 	SpacesDebugLogging bool `hcl:"spaces_debug_logging,optional"`
+
+	requestedFormat cqproto.ConfigFormat
 }
 
-func (Config) Example() string {
-	return `
+func NewConfig(f cqproto.ConfigFormat) *Config {
+	return &Config{
+		requestedFormat: f,
+	}
+}
+
+func (c Config) Example() string {
+	switch c.requestedFormat {
+	case cqproto.ConfigHCL:
+		return `
 		configuration {
-			// API Token to access DigitalOcean resources 
+			// API Token to access DigitalOcean resources
 			// See https://docs.digitalocean.com/reference/api/api-reference/#section/Authentication
 			token = "<YOUR_API_TOKEN_HERE>"
 			// List of regions to fetch spaces from, if not given all regions are assumed
@@ -30,4 +42,28 @@ func (Config) Example() string {
 			// spaces_debug_logging = false
 		}
 `
+	default:
+		return `
+API Token to access DigitalOcean resources
+See https://docs.digitalocean.com/reference/api/api-reference/#section/Authentication
+token: <YOUR_API_TOKEN_HERE>
+List of regions to fetch spaces from, if not given all regions are assumed
+spaces_regions:
+  - nyc3
+  - sfo3
+  - ams3
+  - sgp1
+  - fra1
+Spaces Access Key generated at https://cloud.digitalocean.com/settings/api/tokens
+spaces_access_key: <YOUR_SPACES_ACCESS_KEY>
+Spaces Access Key Id generated at https://cloud.digitalocean.com/settings/api/tokens
+spaces_access_key_id: <YOUR_SPACES_ACCESS_KEY_ID>
+SpacesDebugLogging allows enabling AWS S3 request logging on spaces requests
+spaces_debug_logging: false
+`
+	}
+}
+
+func (c Config) Format() cqproto.ConfigFormat {
+	return c.requestedFormat
 }

--- a/client/testing.go
+++ b/client/testing.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	providertest "github.com/cloudquery/cq-provider-sdk/provider/testing"
@@ -15,8 +16,8 @@ func DOTestHelper(t *testing.T, table *schema.Table) {
 			Name:      "digitalocean_test_provider",
 			Version:   "development",
 			Configure: Configure,
-			Config: func() provider.Config {
-				return &Config{}
+			Config: func(f cqproto.ConfigFormat) provider.Config {
+				return NewConfig(f)
 			},
 			ResourceMap: map[string]*schema.Table{
 				"test_resource": table,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.15.0
 	github.com/aws/smithy-go v1.11.3
-	github.com/cloudquery/cq-provider-sdk v0.12.0
+	github.com/cloudquery/cq-provider-sdk v0.12.1
 	github.com/digitalocean/godo v1.65.0
 	github.com/hashicorp/go-hclog v1.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.15.0
 	github.com/aws/smithy-go v1.11.3
-	github.com/cloudquery/cq-provider-sdk v0.11.4
+	github.com/cloudquery/cq-provider-sdk v0.12.0
 	github.com/digitalocean/godo v1.65.0
 	github.com/hashicorp/go-hclog v1.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAooYjqdltrsGi8I=
-github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
+github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
+github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
-github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1 h1:Y4/VWjb/HLRX1pUoA7H82JoEu5mizNCDlfIeLGXOXSA=
+github.com/cloudquery/cq-provider-sdk v0.12.1/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/cloudquery/cq-provider-digitalocean/client"
 	"github.com/cloudquery/cq-provider-digitalocean/resources"
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	sdkprovider "github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 )
@@ -40,8 +41,8 @@ func Provider() *sdkprovider.Provider {
 			"certificates":    resources.Certificates(),
 			"load_balancers":  resources.LoadBalancers(),
 		},
-		Config: func() sdkprovider.Config {
-			return &client.Config{}
+		Config: func(f cqproto.ConfigFormat) sdkprovider.Config {
+			return client.NewConfig(f)
 		},
 	}
 }


### PR DESCRIPTION
to go with https://github.com/cloudquery/cq-provider-sdk/pull/332 and https://github.com/cloudquery/cloudquery/pull/887

`go run main.go init digitalocean --config config.yml` creates this:
```yaml
cloudquery:
    providers:
        - name: digitalocean
          version: latest
    connection:
        type: postgres
        username: postgres
        password: pass
        host: localhost
        port: 5432
        database: postgres
        sslmode: disable
providers:
    # provider configurations
    - name: digitalocean
      # API Token to access DigitalOcean resources
      # See https://docs.digitalocean.com/reference/api/api-reference/#section/Authentication
      # token: <YOUR_API_TOKEN_HERE>
      # List of regions to fetch spaces from, if not given all regions are assumed
      # spaces_regions:
      #   - nyc3
      #   - sfo3
      #   - ams3
      #   - sgp1
      #   - fra1
      # Spaces Access Key generated at https://cloud.digitalocean.com/settings/api/tokens
      # spaces_access_key: <YOUR_SPACES_ACCESS_KEY>
      # Spaces Access Key Id generated at https://cloud.digitalocean.com/settings/api/tokens
      # spaces_access_key_id: <YOUR_SPACES_ACCESS_KEY_ID>
      # SpacesDebugLogging allows enabling AWS S3 request logging on spaces requests
      # spaces_debug_logging: false
      #  
      # list of resources to fetch
      resources:
        - account
        - balance
        - billing_history
        - cdns
        - certificates
        - databases
        - domains
        - droplets
        - firewalls
        - floating_ips
        - images
        - keys
        - load_balancers
        - projects
        - regions
        - registry
        - sizes
        - snapshots
        - spaces
        - volumes
        - vpcs
```
